### PR TITLE
Efficient getTransactionTraces

### DIFF
--- a/optimism/client.go
+++ b/optimism/client.go
@@ -301,9 +301,14 @@ func (ec *Client) getTransactionTraces(
 	}
 	reqs := make([]rpc.BatchElem, len(txs))
 	for i := range reqs {
+		type batchArgs struct {
+			DisableStack   bool `json:"disableStack"`
+			DisableStorage bool `json:"disableStorage"`
+			DisableMemory  bool `json:"disableMemory"`
+		}
 		reqs[i] = rpc.BatchElem{
 			Method: "debug_traceTransaction",
-			Args:   []interface{}{txs[i].tx.Hash().Hex()},
+			Args:   []interface{}{txs[i].tx.Hash().Hex(), batchArgs{DisableStack: true, DisableStorage: true, DisableMemory: true}},
 			Result: &traces[i],
 		}
 	}


### PR DESCRIPTION
Certain txs (ex: `0x223f531e14bb2e9875c8c7b4dd1c90d70463012226fc0af2a5bf577744050193`) generate extremely large traces that cause l2geth RPC to timeout while writing the HTTP response.
Disabling the unneded stack, memory and storage info from the trace
keeps the response payload small enough to be served..
